### PR TITLE
[PLAT-16583] Adding Build artifacts for linux and arm 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,18 +7,13 @@ on:
 env:
   BUILD_DIR: dist
 
+
 jobs:
   build-and-test:
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-14]
         arch: [amd64, arm64]
-        exclude:
-          - os: macos-14
-            arch: amd64  # no need for macOS + x86
-    env:
-      GOARCH: ${{ matrix.arch }}
 
     steps:
       - uses: actions/checkout@v3
@@ -29,25 +24,23 @@ jobs:
 
       - name: Install build dependencies
         run: |
-          if [[ "$RUNNER_OS" == "Linux" ]]; then
-            sudo apt-get update
-            sudo apt-get install -y make gcc cppcheck gcc-aarch64-linux-gnu
-          elif [[ "$RUNNER_OS" == "macOS" ]]; then
-            brew install make cppcheck
-          fi
+          sudo apt-get update
+          sudo apt-get install -y make gcc cppcheck \
+            gcc-aarch64-linux-gnu  # install ARM64 cross compiler
 
       - name: Set platform-specific env
         run: |
           echo "ARCH=${{ matrix.arch }}" >> $GITHUB_ENV
-          echo "TARGET=earlyoom-${RUNNER_OS,,}-${{ matrix.arch }}" >> $GITHUB_ENV
+          echo "TARGET=earlyoom-linux-${{ matrix.arch }}" >> $GITHUB_ENV
           echo "VERSION=v999-dev-$(git describe --tags --dirty --always || echo vdev)" >> $GITHUB_ENV
+
 
       - name: Build binary
         run: |
           mkdir -p $BUILD_DIR
           make clean
-          if [[ "$RUNNER_OS" == "Linux" && "${ARCH}" == "arm64" ]]; then
-            make CC="aarch64-linux-gnu-gcc -static"
+          if [ "${ARCH}" = "arm64" ]; then
+            make CC=aarch64-linux-gnu-gcc
           else
             make
           fi
@@ -58,10 +51,10 @@ jobs:
       - name: Upload tarball
         uses: actions/upload-artifact@v4
         with:
-          name: earlyoom-${{ matrix.os }}-${{ matrix.arch }}
+          name: earlyoom-${{ matrix.arch }}
           path: ${{ env.BUILD_DIR }}/${{ env.TARGET }}.tar.gz
 
-      - name: Run unit tests (Linux amd64 only)
-        if: matrix.os == 'ubuntu-latest' && matrix.arch == 'amd64'
+      - name: Run unit tests (amd64 only)
+        if: matrix.arch == 'amd64'
         run: make test
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,35 +1,57 @@
-name: CI - Build & Test
+name: CI - Build, Test, Cache
 
 on:
   push:
-    branches: [main, yb-master]
   pull_request:
-    branches: [main, yb-master]
 
 env:
   BUILD_DIR: dist
   VERSION: dev
 
 jobs:
+  setup:
+    runs-on: ubuntu-latest
+    outputs:
+      go-cache-key: ${{ steps.go-cache.outputs.cache-key }}
+    steps:
+      - name: Get date hash for cache key
+        id: go-cache
+        run: echo "cache-key=go-${{ runner.os }}-${{ hashFiles('**/go.sum') }}" >> $GITHUB_OUTPUT
+
   build:
-    name: Build & Test
+    needs: setup
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        os: [linux, darwin]
         arch: [amd64, arm64]
     steps:
       - uses: actions/checkout@v3
 
+      - name: Set target env
+        run: |
+          echo "GOOS=linux" >> $GITHUB_ENV
+          echo "GOARCH=${{ matrix.arch }}" >> $GITHUB_ENV
+          echo "OUT_NAME=earlyoom-linux-${{ matrix.arch }}" >> $GITHUB_ENV
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: 1.21
+
+      - name: Restore Go cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ needs.setup.outputs.go-cache-key }}
+
       - name: Install deps
         run: sudo apt-get update && sudo apt-get install -y make gcc cppcheck
 
-      - name: Build
+      - name: Build binary
         run: |
           mkdir -p $BUILD_DIR
-          export GOOS=${{ matrix.os }}
-          export GOARCH=${{ matrix.arch }}
-          export OUT_NAME=earlyoom-${GOOS}-${GOARCH}
           make clean
           make VERSION=$VERSION OUT_NAME=$BUILD_DIR/$OUT_NAME
           tar czvf $BUILD_DIR/$OUT_NAME.tar.gz -C $BUILD_DIR $(basename $OUT_NAME)
@@ -37,12 +59,20 @@ jobs:
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: earlyoom-${{ matrix.os }}-${{ matrix.arch }}
+          name: earlyoom-linux-${{ matrix.arch }}
           path: |
-            dist/earlyoom-${{ matrix.os }}-${{ matrix.arch }}
-            dist/earlyoom-${{ matrix.os }}-${{ matrix.arch }}.tar.gz
+            ${{ env.BUILD_DIR }}/earlyoom-linux-${{ matrix.arch }}
+            ${{ env.BUILD_DIR }}/earlyoom-linux-${{ matrix.arch }}.tar.gz
 
-      - name: Run unit tests
-        if: matrix.os == 'linux'
+  test:
+    name: Unit Tests (amd64)
+    runs-on: ubuntu-latest
+    if: always()  # always run even if build fails (visible failure)
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install test deps
+        run: sudo apt-get update && sudo apt-get install -y make gcc
+
+      - name: Run tests
         run: make test
-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
         run: |
           echo "ARCH=${{ matrix.arch }}" >> $GITHUB_ENV
           echo "TARGET=earlyoom-linux-${{ matrix.arch }}" >> $GITHUB_ENV
-          echo "VERSION=$(git describe --tags --dirty --always || echo vdev)" >> $GITHUB_ENV
+          echo "VERSION=v-$(git describe --tags --dirty --always || echo vdev)" >> $GITHUB_ENV
 
       - name: Build binary
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: CI - Build, Test, Cache
+name: CI - Build & Test
 
 on:
   push:
@@ -9,55 +9,30 @@ env:
   VERSION: dev
 
 jobs:
-  setup:
-    runs-on: ubuntu-latest
-    outputs:
-      go-cache-key: ${{ steps.go-cache.outputs.cache-key }}
-    steps:
-      - name: Get date hash for cache key
-        id: go-cache
-        run: echo "cache-key=go-${{ runner.os }}-${{ hashFiles('**/go.sum') }}" >> $GITHUB_OUTPUT
-
-  build:
-    needs: setup
+  build-and-test:
     runs-on: ubuntu-latest
     strategy:
       matrix:
         arch: [amd64, arm64]
+
     steps:
       - uses: actions/checkout@v3
+
+      - name: Install dependencies
+        run: sudo apt-get update && sudo apt-get install -y make gcc cppcheck
 
       - name: Set target env
         run: |
           echo "GOOS=linux" >> $GITHUB_ENV
           echo "GOARCH=${{ matrix.arch }}" >> $GITHUB_ENV
-          echo "OUT_NAME=earlyoom-linux-${{ matrix.arch }}" >> $GITHUB_ENV
 
-      - name: Set up Go
-        uses: actions/setup-go@v4
-        with:
-          go-version: 1.21
-
-      - name: Restore Go cache
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ needs.setup.outputs.go-cache-key }}
-
-      - name: Install deps
-        run: sudo apt-get update && sudo apt-get install -y make gcc cppcheck
-
-
-      - name: Build binary
+      - name: Build with make
         run: |
           mkdir -p $BUILD_DIR
           make clean
           make VERSION=$VERSION
           cp earlyoom $BUILD_DIR/earlyoom-linux-${{ matrix.arch }}
           tar czvf $BUILD_DIR/earlyoom-linux-${{ matrix.arch }}.tar.gz -C $BUILD_DIR earlyoom-linux-${{ matrix.arch }}
-
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
@@ -67,15 +42,7 @@ jobs:
             ${{ env.BUILD_DIR }}/earlyoom-linux-${{ matrix.arch }}
             ${{ env.BUILD_DIR }}/earlyoom-linux-${{ matrix.arch }}.tar.gz
 
-  test:
-    name: Unit Tests (amd64)
-    runs-on: ubuntu-latest
-    if: always()  # always run even if build fails (visible failure)
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: Install test deps
-        run: sudo apt-get update && sudo apt-get install -y make gcc
-
-      - name: Run tests
+      - name: Run unit tests (on amd64 only)
+        if: matrix.arch == 'amd64'
         run: make test
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,11 +35,10 @@ jobs:
           elif [[ "$RUNNER_OS" == "macOS" ]]; then
             brew install make cppcheck
           fi
-
       - name: Set platform-specific env
         run: |
           echo "ARCH=${{ matrix.arch }}" >> $GITHUB_ENV
-          echo "TARGET=earlyoom-${RUNNER_OS,,}-${{ matrix.arch }}" >> $GITHUB_ENV
+          echo "TARGET=earlyoom-$(echo "$RUNNER_OS" | tr '[:upper:]' '[:lower:]')-${{ matrix.arch }}" >> $GITHUB_ENV
           echo "VERSION=v999-dev-$(git describe --tags --dirty --always || echo vdev)" >> $GITHUB_ENV
 
       - name: Build binary

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
 
 env:
   BUILD_DIR: dist
-  VERSION: dev
+  VERSION: v-dev
 
 jobs:
   build-and-test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,4 @@
 name: CI
-
 on:
   push:
   pull_request:
@@ -9,71 +8,116 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        arch: [amd64, arm64]
+    env:
+      GOARCH: ${{ matrix.arch }}
+
     steps:
+      - run: ls -l /proc/self/fd
 
-    # Looks like Github Actions leaks fds to child processes
-    # https://github.com/actions/runner/issues/1188
-    - run: ls -l /proc/self/fd
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
-# Build and test in Ubuntu VM provided by Github CI
-    - uses: actions/checkout@v2
-      with:
-        fetch-depth: 0 # Make "git describe" work
-    - run: sudo apt-get install -qq pandoc cppcheck
-    - run: make
-    - run: make test
-    - run: git clean -dxff
-
-# And also build in a number of docker containers of older
-# distributions
-    - name: Build and test in Debian Bullseye
-      uses: addnab/docker-run-action@v3
-      with:
-        image: debian:bullseye
-        options: -v ${{ github.workspace }}:/work
+      - name: Install dependencies
         run: |
-          set -ex
-          apt-get -qq update > /dev/null < /dev/null
-          apt-get -qq install make gcc golang git ca-certificates > /dev/null < /dev/null
-          cd /work
-          make
-          make test
-    - run: git clean -dxff
+          sudo apt-get update -qq
+          sudo apt-get install -y pandoc cppcheck gcc-aarch64-linux-gnu
 
-    - name: Build and test in Amazon Linux 2
-      uses: addnab/docker-run-action@v3
-      with:
-        image: amazonlinux:2
-        options: -v ${{ github.workspace }}:/work
+      - name: Build static binary for ${{ matrix.arch }}
         run: |
-          set -ex
-          yum -y -q install make gcc golang git
-          cd /work
-          git config --global --add safe.directory /work # Fix for: fatal: detected dubious ownership in repository at '/work'
-          make
-          make test
-    - run: git clean -dxff
+          make clean
+          if [ "${{ matrix.arch }}" = "arm64" ]; then
+            make CC="aarch64-linux-gnu-gcc -static"
+            mv earlyoom earlyoom-arm64
+          else
+            make CC="gcc -static"
+            mv earlyoom earlyoom-amd64
+          fi
 
-    - name: Build in Oracle Linux 7 (similar to RHEL 7, CentOS 7)
-      uses: addnab/docker-run-action@v3
-      with:
-        image: oraclelinux:7
-        options: -v ${{ github.workspace }}:/work
-        run: |
-          set -ex
-          yum -y -q install make gcc git
-          cd /work
-          make
-    - run: git clean -dxff
+      - name: Run tests (only for amd64)
+        if: matrix.arch == 'amd64'
+        run: make test
 
-    - name: Build in Oracle Linux 8 (similar to RHEL 8, CentOS 8)
-      uses: addnab/docker-run-action@v3
-      with:
-        image: oraclelinux:8
-        options: -v ${{ github.workspace }}:/work
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: earlyoom-${{ matrix.arch }}
+          path: earlyoom-${{ matrix.arch }}
+
+  docker-matrix:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        image:
+          - debian:bullseye
+          - amazonlinux:2
+          - oraclelinux:7
+          - oraclelinux:8
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Build and test in ${{ matrix.image }}
+        uses: addnab/docker-run-action@v3
+        with:
+          image: ${{ matrix.image }}
+          options: -v ${{ github.workspace }}:/work
+          run: |
+            set -ex
+            cd /work
+            case "${{ matrix.image }}" in
+              debian:bullseye)
+                apt-get -qq update
+                apt-get -qq install make gcc golang git ca-certificates
+                make
+                make test
+                ;;
+              amazonlinux:2)
+                yum -y -q install make gcc golang git
+                git config --global --add safe.directory /work
+                make
+                make test
+                ;;
+              oraclelinux:7)
+                yum -y -q install make gcc git
+                make
+                ;;
+              oraclelinux:8)
+                dnf -y -q install make gcc git
+                make
+                ;;
+            esac
+
+      - run: git clean -dxff
+
+  release:
+    needs: [build]
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
+
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: dist
+
+      - name: Flatten artifacts
         run: |
-          set -ex
-          dnf -y -q install make gcc git
-          cd /work
-          make
-    - run: git clean -dxff
+          mv dist/earlyoom-amd64/earlyoom-amd64 .
+          mv dist/earlyoom-arm64/earlyoom-arm64 .
+
+      - name: Upload to GitHub Release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: |
+            earlyoom-amd64
+            earlyoom-arm64
+          name: Release ${{ github.ref_name }}
+          body: |
+            Statically-linked earlyoom binaries for ${{ github.ref_name }}
+            - `earlyoom-amd64`
+            - `earlyoom-arm64`
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,12 +49,15 @@ jobs:
       - name: Install deps
         run: sudo apt-get update && sudo apt-get install -y make gcc cppcheck
 
+
       - name: Build binary
         run: |
           mkdir -p $BUILD_DIR
           make clean
-          make VERSION=$VERSION OUT_NAME=$BUILD_DIR/$OUT_NAME
-          tar czvf $BUILD_DIR/$OUT_NAME.tar.gz -C $BUILD_DIR $(basename $OUT_NAME)
+          make VERSION=$VERSION
+          cp earlyoom $BUILD_DIR/earlyoom-linux-${{ matrix.arch }}
+          tar czvf $BUILD_DIR/earlyoom-linux-${{ matrix.arch }}.tar.gz -C $BUILD_DIR earlyoom-linux-${{ matrix.arch }}
+
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,10 +35,11 @@ jobs:
           elif [[ "$RUNNER_OS" == "macOS" ]]; then
             brew install make cppcheck
           fi
+
       - name: Set platform-specific env
         run: |
           echo "ARCH=${{ matrix.arch }}" >> $GITHUB_ENV
-          echo "TARGET=earlyoom-$(echo "$RUNNER_OS" | tr '[:upper:]' '[:lower:]')-${{ matrix.arch }}" >> $GITHUB_ENV
+          echo "TARGET=earlyoom-${RUNNER_OS,,}-${{ matrix.arch }}" >> $GITHUB_ENV
           echo "VERSION=v999-dev-$(git describe --tags --dirty --always || echo vdev)" >> $GITHUB_ENV
 
       - name: Build binary

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
 
 env:
   BUILD_DIR: dist
-  VERSION: vdev
+
 
 jobs:
   build-and-test:
@@ -30,15 +30,16 @@ jobs:
         run: |
           echo "ARCH=${{ matrix.arch }}" >> $GITHUB_ENV
           echo "TARGET=earlyoom-linux-${{ matrix.arch }}" >> $GITHUB_ENV
+          echo "VERSION=$(git describe --tags --dirty --always || echo vdev)" >> $GITHUB_ENV
 
       - name: Build binary
         run: |
           mkdir -p $BUILD_DIR
           make clean
           if [ "${ARCH}" = "arm64" ]; then
-            make CC=aarch64-linux-gnu-gcc VERSION=$VERSION
+            make CC=aarch64-linux-gnu-gcc
           else
-            make VERSION=$VERSION
+            make
           fi
           mkdir -p $BUILD_DIR/earlyoom-${VERSION}
           cp earlyoom $BUILD_DIR/earlyoom-${VERSION}/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,13 +7,18 @@ on:
 env:
   BUILD_DIR: dist
 
-
 jobs:
   build-and-test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
+        os: [ubuntu-latest, macos-14]
         arch: [amd64, arm64]
+        exclude:
+          - os: macos-14
+            arch: amd64  # no need for macOS + x86
+    env:
+      GOARCH: ${{ matrix.arch }}
 
     steps:
       - uses: actions/checkout@v3
@@ -24,23 +29,25 @@ jobs:
 
       - name: Install build dependencies
         run: |
-          sudo apt-get update
-          sudo apt-get install -y make gcc cppcheck \
-            gcc-aarch64-linux-gnu  # install ARM64 cross compiler
+          if [[ "$RUNNER_OS" == "Linux" ]]; then
+            sudo apt-get update
+            sudo apt-get install -y make gcc cppcheck gcc-aarch64-linux-gnu
+          elif [[ "$RUNNER_OS" == "macOS" ]]; then
+            brew install make cppcheck
+          fi
 
       - name: Set platform-specific env
         run: |
           echo "ARCH=${{ matrix.arch }}" >> $GITHUB_ENV
-          echo "TARGET=earlyoom-linux-${{ matrix.arch }}" >> $GITHUB_ENV
+          echo "TARGET=earlyoom-${RUNNER_OS,,}-${{ matrix.arch }}" >> $GITHUB_ENV
           echo "VERSION=v999-dev-$(git describe --tags --dirty --always || echo vdev)" >> $GITHUB_ENV
-
 
       - name: Build binary
         run: |
           mkdir -p $BUILD_DIR
           make clean
-          if [ "${ARCH}" = "arm64" ]; then
-            make CC=aarch64-linux-gnu-gcc
+          if [[ "$RUNNER_OS" == "Linux" && "${ARCH}" == "arm64" ]]; then
+            make CC="aarch64-linux-gnu-gcc -static"
           else
             make
           fi
@@ -51,10 +58,10 @@ jobs:
       - name: Upload tarball
         uses: actions/upload-artifact@v4
         with:
-          name: earlyoom-${{ matrix.arch }}
+          name: earlyoom-${{ matrix.os }}-${{ matrix.arch }}
           path: ${{ env.BUILD_DIR }}/${{ env.TARGET }}.tar.gz
 
-      - name: Run unit tests (amd64 only)
-        if: matrix.arch == 'amd64'
+      - name: Run unit tests (Linux amd64 only)
+        if: matrix.os == 'ubuntu-latest' && matrix.arch == 'amd64'
         run: make test
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,7 @@ jobs:
         with:
           fetch-depth: 0
           fetch-tags: true
+          ref: ${{ github.ref }}
 
       - name: Install build dependencies
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,9 @@ jobs:
           - oraclelinux:8
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
 
       - name: Build and test in ${{ matrix.image }}
         uses: addnab/docker-run-action@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
 
 env:
   BUILD_DIR: dist
-  VERSION: v-dev
+  VERSION: vdev  # use 'v1.2.3' from tag in release workflow
 
 jobs:
   build-and-test:
@@ -26,21 +26,23 @@ jobs:
           echo "GOOS=linux" >> $GITHUB_ENV
           echo "GOARCH=${{ matrix.arch }}" >> $GITHUB_ENV
 
-      - name: Build with make
+      - name: Build
         run: |
           mkdir -p $BUILD_DIR
           make clean
           make VERSION=$VERSION
-          cp earlyoom $BUILD_DIR/earlyoom-linux-${{ matrix.arch }}
-          tar czvf $BUILD_DIR/earlyoom-linux-${{ matrix.arch }}.tar.gz -C $BUILD_DIR earlyoom-linux-${{ matrix.arch }}
 
-      - name: Upload artifacts
+      - name: Package into tarball
+        run: |
+          mkdir -p $BUILD_DIR/earlyoom-${VERSION}
+          cp earlyoom $BUILD_DIR/earlyoom-${VERSION}/
+          tar czvf $BUILD_DIR/earlyoom-linux-${{ matrix.arch }}.tar.gz -C $BUILD_DIR earlyoom-${VERSION}
+
+      - name: Upload tarball
         uses: actions/upload-artifact@v4
         with:
           name: earlyoom-linux-${{ matrix.arch }}
-          path: |
-            ${{ env.BUILD_DIR }}/earlyoom-linux-${{ matrix.arch }}
-            ${{ env.BUILD_DIR }}/earlyoom-linux-${{ matrix.arch }}.tar.gz
+          path: ${{ env.BUILD_DIR }}/earlyoom-linux-${{ matrix.arch }}.tar.gz
 
       - name: Run unit tests (on amd64 only)
         if: matrix.arch == 'amd64'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
 
 env:
   BUILD_DIR: dist
-  VERSION: vdev  # use 'v1.2.3' from tag in release workflow
+  VERSION: vdev
 
 jobs:
   build-and-test:
@@ -18,33 +18,37 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Install dependencies
-        run: sudo apt-get update && sudo apt-get install -y make gcc cppcheck
-
-      - name: Set target env
+      - name: Install build dependencies
         run: |
-          echo "GOOS=linux" >> $GITHUB_ENV
-          echo "GOARCH=${{ matrix.arch }}" >> $GITHUB_ENV
+          sudo apt-get update
+          sudo apt-get install -y make gcc cppcheck \
+            gcc-aarch64-linux-gnu  # install ARM64 cross compiler
 
-      - name: Build
+      - name: Set platform-specific env
+        run: |
+          echo "ARCH=${{ matrix.arch }}" >> $GITHUB_ENV
+          echo "TARGET=earlyoom-linux-${{ matrix.arch }}" >> $GITHUB_ENV
+
+      - name: Build binary
         run: |
           mkdir -p $BUILD_DIR
           make clean
-          make VERSION=$VERSION
-
-      - name: Package into tarball
-        run: |
+          if [ "${ARCH}" = "arm64" ]; then
+            make CC=aarch64-linux-gnu-gcc VERSION=$VERSION
+          else
+            make VERSION=$VERSION
+          fi
           mkdir -p $BUILD_DIR/earlyoom-${VERSION}
           cp earlyoom $BUILD_DIR/earlyoom-${VERSION}/
-          tar czvf $BUILD_DIR/earlyoom-linux-${{ matrix.arch }}.tar.gz -C $BUILD_DIR earlyoom-${VERSION}
+          tar czvf $BUILD_DIR/${TARGET}.tar.gz -C $BUILD_DIR earlyoom-${VERSION}
 
       - name: Upload tarball
         uses: actions/upload-artifact@v4
         with:
-          name: earlyoom-linux-${{ matrix.arch }}
-          path: ${{ env.BUILD_DIR }}/earlyoom-linux-${{ matrix.arch }}.tar.gz
+          name: earlyoom-${{ matrix.arch }}
+          path: ${{ env.BUILD_DIR }}/${{ env.TARGET }}.tar.gz
 
-      - name: Run unit tests (on amd64 only)
+      - name: Run unit tests (amd64 only)
         if: matrix.arch == 'amd64'
         run: make test
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
+          fetch-tags: true
 
       - name: Install build dependencies
         run: |
@@ -30,7 +31,8 @@ jobs:
         run: |
           echo "ARCH=${{ matrix.arch }}" >> $GITHUB_ENV
           echo "TARGET=earlyoom-linux-${{ matrix.arch }}" >> $GITHUB_ENV
-          echo "VERSION=v-$(git describe --tags --dirty --always || echo vdev)" >> $GITHUB_ENV
+          echo "VERSION=$(git describe --tags --dirty --always || echo vdev)" >> $GITHUB_ENV
+
 
       - name: Build binary
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - name: Install build dependencies
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
         run: |
           echo "ARCH=${{ matrix.arch }}" >> $GITHUB_ENV
           echo "TARGET=earlyoom-linux-${{ matrix.arch }}" >> $GITHUB_ENV
-          echo "VERSION=$(git describe --tags --dirty --always || echo vdev)" >> $GITHUB_ENV
+          echo "VERSION=v999-dev-$(git describe --tags --dirty --always || echo vdev)" >> $GITHUB_ENV
 
 
       - name: Build binary

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -45,4 +45,3 @@ jobs:
       - name: Run unit tests
         if: matrix.os == 'linux'
         run: make test
-

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,47 +1,50 @@
-name: CI - Build & Test
+name: Release
 
 on:
   push:
-    branches: [main, yb-master]
-  pull_request:
-    branches: [main, yb-master]
+    tags:
+      - 'v*'  # runs on v1.2.3-style tags
 
 env:
   BUILD_DIR: dist
-  VERSION: dev
 
 jobs:
-  build:
-    name: Build & Test
+  release:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        os: [linux, darwin]
         arch: [amd64, arm64]
+
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          fetch-tags: true
 
-      - name: Install deps
-        run: sudo apt-get update && sudo apt-get install -y make gcc cppcheck
+      - name: Install build deps
+        run: sudo apt-get update && sudo apt-get install -y make gcc cppcheck gcc-aarch64-linux-gnu
 
-      - name: Build
+      - name: Extract version from tag
+        id: tag
+        run: |
+          echo "VERSION=$(git describe --tags --dirty --always)" >> $GITHUB_ENV
+
+      - name: Build binary
         run: |
           mkdir -p $BUILD_DIR
-          export GOOS=${{ matrix.os }}
-          export GOARCH=${{ matrix.arch }}
-          export OUT_NAME=earlyoom-${GOOS}-${GOARCH}
           make clean
-          make VERSION=$VERSION OUT_NAME=$BUILD_DIR/$OUT_NAME
-          tar czvf $BUILD_DIR/$OUT_NAME.tar.gz -C $BUILD_DIR $(basename $OUT_NAME)
+          if [ "${{ matrix.arch }}" = "arm64" ]; then
+            make CC=aarch64-linux-gnu-gcc
+          else
+            make
+          fi
+          mkdir -p $BUILD_DIR/earlyoom-${VERSION}
+          cp earlyoom $BUILD_DIR/earlyoom-${VERSION}/
+          tar czvf $BUILD_DIR/earlyoom-linux-${{ matrix.arch }}.tar.gz -C $BUILD_DIR earlyoom-${VERSION}
 
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+      - name: Upload release asset
+        uses: softprops/action-gh-release@v1
         with:
-          name: earlyoom-${{ matrix.os }}-${{ matrix.arch }}
-          path: |
-            dist/earlyoom-${{ matrix.os }}-${{ matrix.arch }}
-            dist/earlyoom-${{ matrix.os }}-${{ matrix.arch }}.tar.gz
-
-      - name: Run unit tests
-        if: matrix.os == 'linux'
-        run: make test
+          files: ${{ env.BUILD_DIR }}/earlyoom-linux-${{ matrix.arch }}.tar.gz
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Setting GIT_DIR keeps git from ascending to parent directories
 # and gives a nicer error message
-VERSION ?= $(shell GIT_DIR=$(shell pwd)/.git git describe --tags --dirty)
+VERSION ?= $(shell GIT_DIR=$(shell pwd)/.git git describe --tags --dirty --always 2>/dev/null || echo vdev)
 ifeq ($(VERSION),)
 VERSION := "v(unknown version)"
 $(warning Could not get version from git, setting to $(VERSION))

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 # and gives a nicer error message
 VERSION ?= $(shell GIT_DIR=$(shell pwd)/.git git describe --tags --dirty)
 ifeq ($(VERSION),)
-VERSION := "9.9.9-b1"
+VERSION := "v(unknown version)"
 $(warning Could not get version from git, setting to $(VERSION))
 endif
 CFLAGS += -Wall -Wextra -Wformat-security -Wconversion -DVERSION=\"$(VERSION)\" -g -fstack-protector-all -std=gnu99

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 # and gives a nicer error message
 VERSION ?= $(shell GIT_DIR=$(shell pwd)/.git git describe --tags --dirty)
 ifeq ($(VERSION),)
-VERSION := "(unknown version)"
+VERSION := "9.9.9-b1"
 $(warning Could not get version from git, setting to $(VERSION))
 endif
 CFLAGS += -Wall -Wextra -Wformat-security -Wconversion -DVERSION=\"$(VERSION)\" -g -fstack-protector-all -std=gnu99


### PR DESCRIPTION
Currently we only build the basic artifacts which includes just the binary build for earlyoom. 
This gets generated on every commit that is pushed, we can reduce the frequency if its too agressive. 

We also added a release automation so to make a new release we have to  create a 
release TAG
git tag -a v999.0 -m "testing release"
git push origin v1.9.0
on the yb-master branch
With pushing the tag release automation will generate a release for that tag. 

Testing done:
Unit tests fixed
Tested the arm64 build in a docker container it comes up

```
docker run --rm -v $PWD:/app -w /app arm64v8/ubuntu ./earlyoom-arm64 --help

Unable to find image 'arm64v8/ubuntu:latest' locally
latest: Pulling from arm64v8/ubuntu
49b96e96358d: Pull complete 
Digest: sha256:cc529ee48024614ce5f9cfe2c0d303b3084e252640d011563f5b1d26fe1a2894
Status: Downloaded newer image for arm64v8/ubuntu:latest
earlyoom v(unknown version)
Usage: ./earlyoom-arm64 [OPTION]...

 -m PERCENT[,KILL_PERCENT] set available memory minimum to PERCENT of total
              (default 10 %).
              earlyoom sends SIGTERM once below PERCENT, then
              SIGKILL once below KILL_PERCENT (default PERCENT/2).
 -s PERCENT[,KILL_PERCENT] set free swap minimum to PERCENT of total (default
              10 %).
              Note: both memory and swap must be below minimum for
              earlyoom to act.
 -M SIZE[,KILL_SIZE]    set available memory minimum to SIZE KiB
 -S SIZE[,KILL_SIZE]    set free swap minimum to SIZE KiB
 -n            enable d-bus notifications
 -N /PATH/TO/SCRIPT    call script after oom kill
 -g            kill all processes within a process group
 -d, --debug        enable debugging messages
 -v            print version information and exit
 -r INTERVAL        memory report interval in seconds (default 1), set
              to 0 to disable completely
 -p            set niceness of earlyoom to -20 and oom_score_adj to
              -100
 --ignore-root-user    do not kill processes owned by root
 --sort-by-rss       find process with the largest rss (default oom_score)
 --prefer REGEX      prefer to kill processes matching REGEX
 --avoid REGEX       avoid killing processes matching REGEX
 --ignore REGEX      ignore processes matching REGEX
 --dryrun         dry run (do not kill any processes)
 --syslog         use syslog instead of std streams
```

